### PR TITLE
`"mdast"` の型情報が無くて型チェックが落ちていたので追加

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@repo/style": "workspace:*",
-    "@repo/ui": "workspace:*",
     "@repo/typescript-config": "workspace:*",
+    "@repo/ui": "workspace:*",
     "@types/node": "18.15.0",
     "@types/react": "19.0.10",
     "@types/react-dom": "19.0.4",
@@ -41,6 +41,7 @@
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
+    "@types/mdast": "^4.0.4",
     "@types/remark-heading-id": "^1.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
     devDependencies:
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/remark-heading-id':
         specifier: ^1.0.0
         version: 1.0.0


### PR DESCRIPTION
npm は間接的な dependencies で通ってしまっていたのが、pnpm だと厳格にチェックされるようになったから（？）