### PR TITLE
fix: 本来 key が不要な場所の jsx 構築処理を修正

### DIFF
--- a/packages/style/src/jsx-dev-runtime.ts
+++ b/packages/style/src/jsx-dev-runtime.ts
@@ -15,11 +15,20 @@ export const jsxDEV: typeof ReactJSXRuntimeDev.jsxDEV = (
   const s = processCssForJsx(props);
   if (s) {
     const { props, styleElem } = s;
+    const element = ReactJSXRuntimeDev.jsxDEV(
+      type,
+      props,
+      undefined,
+      isStaticChildren,
+      source,
+      self,
+    );
+
     return ReactJSXRuntimeDev.jsxDEV(
       Fragment,
-      { children: [styleElem, React.createElement(type, props)] },
+      { children: [styleElem, element] },
       key,
-      isStaticChildren,
+      true, // isStaticChildren
       source,
       self,
     );

--- a/packages/style/src/jsx-runtime.ts
+++ b/packages/style/src/jsx-runtime.ts
@@ -10,7 +10,7 @@ export const jsx: typeof ReactJSXRuntime.jsx = (type, props, key) => {
   const s = processCssForJsx(props);
   if (s) {
     const { props, styleElem } = s;
-    return ReactJSXRuntime.jsx(
+    return ReactJSXRuntime.jsxs(
       Fragment,
       { children: [styleElem, ReactJSXRuntime.jsx(type, props, key)] },
       key,


### PR DESCRIPTION
- コンパイル時点で要素の数が決まっている、複数の要素を並べて書いた結果としての ReactNode の配列
- 動的に構築された ReactNode の配列

React および JSX は、jsx / jsxs の使い分けや、jsxDev の isStaticChildren によって両者を区別している。

see: https://zenn.dev/uhyo/articles/react17-new-jsx-transform

今回は、前者として扱うべき式を、後者として書いてしまっていたので、「key が欠けている」旨のエラーが発生していた。その部分を修正した。