### PR TITLE
build: safe-chain の minimum package age を既定値に戻す

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,5 @@ jobs:
       - name: Setup AikidoSec/Safe-Chain
         run: |
           curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
-      - run: |
-          export SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=6
-          pnpm install
+      - run: pnpm install
       - run: pnpm run check


### PR DESCRIPTION
#351 は一時的対応なので、後片付け